### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Afterwards you simply have to define a ```path``` for ```/nucleus``` pointing to
 		demand
 			.configure({
 				pattern: {
-					'/nucleus': '//cdn.jsdelivr.net/qoopido.nucleus/1.0.0'
+					'/nucleus': '//cdn.jsdelivr.net/npm/qoopido.nucleus@3.0.5/dist/base.js'
 				},
 				modules: {
 				}


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/qoopido.nucleus.

Feel free to ping me if you have any questions regarding this change.